### PR TITLE
Debug bad request for milestone plans

### DIFF
--- a/src/controllers/plan.controller.js
+++ b/src/controllers/plan.controller.js
@@ -12,7 +12,8 @@ const createPlans = catchAsync(async (req, res) => {
 
 const queryPlans = catchAsync(async (req, res) => {
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
-  const result = await planService.queryPlans(options);
+  const filters = pick(req.query, ['roadmapId', 'milestoneId']);
+  const result = await planService.queryPlans({ ...options, ...filters });
 
   res.send(result);
 });

--- a/src/validations/plan.validation.ts
+++ b/src/validations/plan.validation.ts
@@ -55,8 +55,10 @@ export const queryPlans = {
   query: z
     .object({
       sortBy: z.string(),
-      limit: z.number().int().min(1),
-      page: z.number().int().min(1),
+      limit: z.coerce.number().int().min(1),
+      page: z.coerce.number().int().min(1),
+      roadmapId: zObjectId,
+      milestoneId: zObjectId,
     })
     .partial(),
 };


### PR DESCRIPTION
Enable querying plans by roadmap and milestone IDs to support fetching milestone-specific plans.

Previously, the API returned a bad request when `roadmapId` and `milestoneId` were provided in the query parameters, as it was not configured to accept or process them.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1a1b3ab-5534-4674-9609-f3d070ea940b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1a1b3ab-5534-4674-9609-f3d070ea940b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

